### PR TITLE
Resolve prebuild issue

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,7 +20,6 @@ vscode:
     # Laravel
     - shufo.vscode-blade-formatter
     - amiralizadeh9480.laravel-extra-intellisense
-    - absszero.vscode-laravel-goto
     - onecentlin.laravel5-snippets
 
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,8 @@ tasks:
     command: |
       ddev start -y
       gp ports await 8080 && gp preview $(gp url 8080)
-# VScode xdebug extension
+
+# VScode extensions
 vscode:
   extensions:
     - GitHub.vscode-pull-request-github


### PR DESCRIPTION
Generate a valid prebuild

## Problem

Clicking the `Gitpod` button starts a session, however:
- session downloads DDEV
- session downloads DDEV images
- session run composer install

These should all be done as part of prebuild.

## Solution

Improve `.gitpod.yml`

## Test

- Click `gitpod` button
- Terminal prompt should be soon
- Should NOT see download progress for DDEV or DDEV images

