### PR TITLE
feat: remove hardcoded project name

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,4 +1,3 @@
-name: lara10-base-demo
 type: laravel
 docroot: public
 php_version: "8.1"


### PR DESCRIPTION
## Problem

When cloning this project, the name configured for DDEV must be changed.

## Solution

By deleting the name from config, DDEV will generate the name based on the project folder.

<a href="https://gitpod.io/#https://github.com/tyler36/lara10-base-demo/pull/2"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

