### PR TITLE
Add ENV for vite in Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,6 +7,8 @@ tasks:
       ddev start -y
       ddev composer install
       ddev php artisan key:generate
+      echo VITE_PROJECT_DIR=. > ./.ddev/.env
+      echo VITE_JS_PACKAGE_MGR=npm >> ./.ddev/.env
     command: |
       ddev start -y
       gp ports await 8080 && gp preview $(gp url 8080)


### PR DESCRIPTION
The vite addon requires ENVs to be set.

This PR creates a ENV file for DDEV and sets:
- Vite project directory to root
- Prefer NPM as package manager